### PR TITLE
Add screen information to version stats

### DIFF
--- a/PosthogFC.py
+++ b/PosthogFC.py
@@ -83,6 +83,9 @@ def posthog_fc_version(tag):
     """Send FreeCAD version to Posthog"""
     global posthog
     release = FreeCAD.Version()
+    screen = FreeCADGui.getMainWindow().screen()
+    screen_size = screen.availableSize()
+
     posthog.capture(
         anonymous_id,
         event="freecad_version",
@@ -91,6 +94,8 @@ def posthog_fc_version(tag):
             "version_major": release[0],
             "version_minor": release[1],
             "version_patch": release[2],
+            "screen_resolution": f"{screen_size.width()}x{screen_size.height()}",
+            "screen_dpi": screen.devicePixelRatio(),
             "$process_person_profile": False,  # Do not include person information
         },
     )

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The output of the following Python commands:
 * platform.system()
 * platform.version()
 * platform.python_version()
+* FreeCADGui.getMainWindow().screen().availableSize()
+* FreeCADGui.getMainWindow().screen().devicePixelRatio()
 
 ## Future plans
 Eventually if FreeCAD crashes while this addon is running, crash data will automatically be sent to the server.


### PR DESCRIPTION
This adds information about screen size (width x height) and DPI to the freecad_version event.

This information would be very much useful for DWG to see how much screen space users usually have and if they use scaling.